### PR TITLE
Fix openshift deployment issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN microdnf -y install wget git subversion \
 RUN wget -qO /opt/windup.zip https://repo1.maven.org/maven2/org/jboss/windup/mta-cli/5.2.1.Final/mta-cli-5.2.1.Final-offline.zip \
  && unzip /opt/windup.zip -d /opt \
  && rm /opt/windup.zip \
- && ln -s /opt/mta-cli-5.2.1.Final/bin/mta-cli /opt/windup  
+ && ln -s /opt/mta-cli-5.2.1.Final/bin/mta-cli /opt/windup \
+ && chmod 777 /home/jboss
 COPY --from=builder /opt/app-root/src/bin/addon /usr/local/bin/addon
 USER jboss
 ENTRYPOINT ["/usr/local/bin/addon"]

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -20,7 +21,8 @@ type Command struct {
 // Run command.
 func (r *Command) Run() (err error) {
 	addon.Activity(
-		"[CMD] Running: %s %s",
+		"[CMD] uid:%d Running: %s %s",
+		os.Getuid(),
 		r.Path,
 		strings.Join(r.Options, " "))
 	cmd := exec.Command(r.Path, r.Options...)


### PR DESCRIPTION
Windup seems to be hard coded to write logs in $HOME/.mta.  This is not an issue in kubernetes because the container runs as the _jboss_ user.  However, openshift overrides and runs the container as a random generated user.
The simplest fix is to open up the /home/jboss permissions.