### PR TITLE
Tackle-708: Fix maven & windup not focused on path specified in repository.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ var (
 	HomeDir   = ""
 	BinDir    = ""
 	SourceDir = ""
+	AppDir    = ""
 	Dir       = ""
 )
 
@@ -98,6 +99,7 @@ func main() {
 					path.Base(
 						application.Repository.URL),
 					".")[0])
+			AppDir = path.Join(SourceDir, application.Repository.Path)
 			var r repository.Repository
 			r, err = repository.New(SourceDir, application)
 			if err != nil {
@@ -111,7 +113,7 @@ func main() {
 				return
 			}
 			if d.Mode.WithDeps {
-				err = maven.Fetch(SourceDir)
+				err = maven.Fetch(AppDir)
 				if err != nil {
 					return
 				}

--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -148,7 +148,7 @@ func (r *Mode) AddOptions(options *command.Options) (err error) {
 		}
 	} else {
 		options.Add("--sourceMode")
-		options.Add("--input", SourceDir)
+		options.Add("--input", AppDir)
 	}
 	if r.Diva {
 		options.Add("--enableTransactionAnalysis")


### PR DESCRIPTION
Both maven and windup need to _operate_ within the (optional) `path` defined in the application repository.

https://issues.redhat.com/browse/TACKLE-708

Note: ignore the incorrect issue # in the branch name.