### PR TITLE
Tackle-721: Support multi-module applications.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,6 +86,9 @@ func main() {
 			return
 		}
 		//
+		// The application has modules.
+		var hasModules bool
+		//
 		// Fetch repository.
 		if !d.Mode.Binary {
 			addon.Total(2)
@@ -113,6 +116,16 @@ func main() {
 				return
 			}
 			if d.Mode.WithDeps {
+				hasModules, err = maven.HasModules(SourceDir)
+				if err != nil {
+					return
+				}
+				if hasModules {
+					err = maven.InstallArtifacts(SourceDir)
+					if err != nil {
+						return
+					}
+				}
 				err = maven.Fetch(AppDir)
 				if err != nil {
 					return
@@ -133,6 +146,14 @@ func main() {
 			addon.Increment()
 		} else {
 			return
+		}
+		//
+		// Clean up.
+		if hasModules {
+			err = maven.DeleteArtifacts(SourceDir)
+			if err != nil {
+				return
+			}
 		}
 		return
 	})

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-
 
 require (
 	github.com/konveyor/controller v0.8.0
-	github.com/konveyor/tackle2-addon v0.0.0-20220524190230-fab33fa07dc2
+	github.com/konveyor/tackle2-addon v0.0.0-20220810150105-90fb8e0aa489
 	github.com/konveyor/tackle2-hub v0.0.0-20220523222112-ad8a69ae5031
 )

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
-github.com/konveyor/tackle2-addon v0.0.0-20220524190230-fab33fa07dc2 h1:895NLJUTrxLRYHPTk4N8vOCNyH/TkOL1cRXY/qvook8=
-github.com/konveyor/tackle2-addon v0.0.0-20220524190230-fab33fa07dc2/go.mod h1:MFNKAQREQnKkSWwIMadds8QbWlQw+ur41Cyg1GKOXuE=
+github.com/konveyor/tackle2-addon v0.0.0-20220810150105-90fb8e0aa489 h1:XepGxQKLcI+lnBlZW3ec7qENzIhH2XXlcRVJNETylK8=
+github.com/konveyor/tackle2-addon v0.0.0-20220810150105-90fb8e0aa489/go.mod h1:MFNKAQREQnKkSWwIMadds8QbWlQw+ur41Cyg1GKOXuE=
 github.com/konveyor/tackle2-hub v0.0.0-20220510102650-542558f3f9cb/go.mod h1:WcxWlSwZlupU0Lp00k6MfnkDR3vkk5Ba5Nq6jmViywk=
 github.com/konveyor/tackle2-hub v0.0.0-20220523222112-ad8a69ae5031 h1:3LwSx/QJgqvDOxOgwIrLzidg5qwj6kAEnOabJxGtkSI=
 github.com/konveyor/tackle2-hub v0.0.0-20220523222112-ad8a69ae5031/go.mod h1:WcxWlSwZlupU0Lp00k6MfnkDR3vkk5Ba5Nq6jmViywk=


### PR DESCRIPTION
Support multi-module applications.
Look at the POM file to determine if an application has multiple modules.
```
    <modules>
		<module>daytrader-ee7-ejb</module>
		<module>daytrader-ee7-web</module>
		<module>daytrader-ee7</module>
    </modules>
```
If +deps and multitple modules, do a maven install before running the maven copy deps.  Then, delete the installed artifacts to prevent filling up the m2 cache.

Requires: https://github.com/konveyor/tackle2-addon/pull/9 for additional maven support.

https://issues.redhat.com/browse/TACKLE-721