### PR TITLE
Discontinue use of deprecated --sourceMode option.

### DIFF
--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -147,7 +147,6 @@ func (r *Mode) AddOptions(options *command.Options) (err error) {
 			options.Add("--input", pathlib.Dir(binDir))
 		}
 	} else {
-		options.Add("--sourceMode")
 		options.Add("--input", AppDir)
 	}
 	if r.Diva {


### PR DESCRIPTION
The `--sourceMode` option is deprecated and has a new side effect of ignoring dependencies.  As a result, the source+deps is broken. 

https://issues.redhat.com/browse/TACKLE-821