### PR TITLE
[backport 2.1.1] Discontinue use of deprecated --sourceMode option.

### DIFF
--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -147,7 +147,6 @@ func (r *Mode) AddOptions(options *command.Options) (err error) {
 			options.Add("--input", pathlib.Dir(binDir))
 		}
 	} else {
-		options.Add("--sourceMode")
 		options.Add("--input", AppDir)
 	}
 	if r.Diva {


### PR DESCRIPTION
back-port: https://github.com/konveyor/tackle2-addon-windup/pull/57