### PR TITLE
[backport-2.1.2] Tackle-828: Latest addon with command RunWith() and RunSilentWith()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,6 @@ replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-
 
 require (
 	github.com/konveyor/controller v0.8.0
-	github.com/konveyor/tackle2-addon v0.0.0-20220825190350-2876255c6f83
+	github.com/konveyor/tackle2-addon v0.0.0-20221004213711-91dcb11203a4
 	github.com/konveyor/tackle2-hub v0.0.0-20220523222112-ad8a69ae5031
 )

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
-github.com/konveyor/tackle2-addon v0.0.0-20220825190350-2876255c6f83 h1:eSqmzD47dh4XpI/z5pwks5/vWkppqh5bHdzAXnpM3+E=
-github.com/konveyor/tackle2-addon v0.0.0-20220825190350-2876255c6f83/go.mod h1:MFNKAQREQnKkSWwIMadds8QbWlQw+ur41Cyg1GKOXuE=
+github.com/konveyor/tackle2-addon v0.0.0-20221004213711-91dcb11203a4 h1:nW5/v0h/d741c6NnZCidUQwiQogZKKU1c4XvPv6UCtg=
+github.com/konveyor/tackle2-addon v0.0.0-20221004213711-91dcb11203a4/go.mod h1:MFNKAQREQnKkSWwIMadds8QbWlQw+ur41Cyg1GKOXuE=
 github.com/konveyor/tackle2-hub v0.0.0-20220510102650-542558f3f9cb/go.mod h1:WcxWlSwZlupU0Lp00k6MfnkDR3vkk5Ba5Nq6jmViywk=
 github.com/konveyor/tackle2-hub v0.0.0-20220523222112-ad8a69ae5031 h1:3LwSx/QJgqvDOxOgwIrLzidg5qwj6kAEnOabJxGtkSI=
 github.com/konveyor/tackle2-hub v0.0.0-20220523222112-ad8a69ae5031/go.mod h1:WcxWlSwZlupU0Lp00k6MfnkDR3vkk5Ba5Nq6jmViywk=


### PR DESCRIPTION
backport: https://github.com/konveyor/tackle2-addon-windup/pull/60