### PR TITLE
Update windup to 6.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN make cmd
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER root
+RUN microdnf -y update && microdnf -y clean all
 RUN echo -e "[centos8]" \
  "\nname = centos8" \
  "\nbaseurl = http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/" \
@@ -15,20 +16,13 @@ RUN echo -e "[WandiscoSVN]" \
  "\nbaseurl=http://opensource.wandisco.com/centos/6/svn-1.9/RPMS/$basearch/" \
  "\nenabled=1" \
  "\ngpgcheck=0" > /etc/yum.repos.d/wandisco.repo
-RUN microdnf -y install \
-  java-11-openjdk-headless \
-  openssh-clients \
-  unzip \
-  wget \
-  git \
-  subversion \
-  maven \
- && microdnf -y clean all
-ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.0.0.Final/tackle-cli-6.0.0.Final-offline.zip
+RUN microdnf -y install java-11-openjdk-headless openssh-clients unzip wget git subversion maven && microdnf -y clean all
+ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.0.Alpha1/tackle-cli-6.1.0.Alpha1-offline.zip
 RUN wget -qO /opt/windup.zip $WINDUP \
  && unzip /opt/windup.zip -d /opt \
  && rm /opt/windup.zip \
- && ln -s /opt/tackle-cli-6.0.0.Final/bin/windup-cli /opt/windup
+ && ln -s /opt/tackle-cli-*/bin/windup-cli /opt/windup
+
 ENV HOME=/working \
     JAVA_HOME="/usr/lib/jvm/jre-11" \
     JAVA_VENDOR="openjdk" \


### PR DESCRIPTION
- Update windup Tackle CLI to release 6.1.0alpha1
- Ensure base image is always updated

Signed-off-by: Franco Bladilo <fbladilo@redhat.com>