### PR TITLE
windup 6.1.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ git \
 subversion \
 maven \
 && microdnf -y clean all
-ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.0.Final/tackle-cli-6.1.0.Final-offline.zip
+ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.2.Final/tackle-cli-6.1.2.Final-offline.zip
 RUN wget -qO /opt/windup.zip $WINDUP \
  && unzip /opt/windup.zip -d /opt \
  && rm /opt/windup.zip \


### PR DESCRIPTION
Upgrade to windup 6.1.2.  This needs to be included in Tackle 2.1.3.