### PR TITLE
:ghost: allow windup action to take host+namespace

### DIFF
--- a/.github/actions/test-e2e-windup/action.yml
+++ b/.github/actions/test-e2e-windup/action.yml
@@ -1,10 +1,21 @@
 name: Test windup e2e
 description: Test Windup Addon End-to-End.
 
+inputs:
+  host:
+    description: Konveyor Host
+    default: localhost:8080/hub
+  namespace:
+    description: Konveyor Namespace
+    default: konveyor-tackle
+
 runs:
   using: "composite"
   steps:
   - name: test-e2e
-    run: make test-e2e
+    run: |
+      export HOST="${{ inputs.host }}"
+      export NAMESPACE="${{ inputs.namespace }}"
+      make test-e2e
     working-directory: ${{ github.action_path }}/../../..
     shell: bash

--- a/.github/workflows/test-windup.yml
+++ b/.github/workflows/test-windup.yml
@@ -53,4 +53,5 @@ jobs:
       - name: Run End-to-End Tests
         run: |
           export HOST=$(minikube ip)/hub
+          export NAMESPACE=$(kubectl get tackles.tackle.konveyor.io --all-namespaces --no-headers | awk '{print $1}')
           make test-e2e

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o xtrace
 
 HOST="${HOST:-localhost:8080}"
-HUB_NAMESPACE="${HUB_NAMESPACE:-konveyor-tackle}"
+NAMESPACE="${NAMESPACE:-konveyor-tackle}"
 
 fail_test() {
   APP_ID=$1
@@ -44,11 +44,11 @@ fail_test() {
     kubectl logs --namespace ${TASK_POD_NAMESPACE} ${TASK_POD_NAME}
   fi
 
-  echo "Every deployment in ${HUB_NAMESPACE}"
-  kubectl describe --namespace ${HUB_NAMESPACE} deployments
+  echo "Every deployment in ${NAMESPACE}"
+  kubectl describe --namespace ${NAMESPACE} deployments
 
   echo "Logs from the hub"
-  kubectl logs --namespace ${HUB_NAMESPACE} deployments/tackle-hub
+  kubectl logs --namespace ${NAMESPACE} deployments/tackle-hub
 
   exit 2
 }


### PR DESCRIPTION
This makes it so, when the action is called, the host and namespace can be defined.

Signed-off-by: David Zager <david.j.zager@gmail.com>