### PR TITLE
:sparkles: Add Tagging support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ git \
 subversion \
 maven \
 && microdnf -y clean all
-ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.2.Final/tackle-cli-6.1.2.Final-offline.zip
+ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.4.Final/tackle-cli-6.1.4.Final-offline.zip
 RUN wget -qO /opt/windup.zip $WINDUP \
  && unzip /opt/windup.zip -d /opt \
  && rm /opt/windup.zip \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,8 @@ type Data struct {
 	Scope Scope `json:"scope"`
 	// Rules options.
 	Rules *Rules `json:"rules"`
+	// Tagger options.
+	Tagger Tagger `json:"tagger"`
 }
 
 //
@@ -185,13 +187,21 @@ func main() {
 			return
 		}
 		addon.Activity(
-			"[BUCKET} Report updated:%s duration:%v.",
+			"[BUCKET] Report updated:%s duration:%v.",
 			d.Output,
 			time.Since(mark))
 		//
 		// Clean up.
 		if hasModules {
 			err = maven.DeleteArtifacts(SourceDir)
+			if err != nil {
+				return
+			}
+		}
+		//
+		// Tagging.
+		if d.Tagger.Enabled {
+			err = d.Tagger.Update(application.ID)
 			if err != nil {
 				return
 			}

--- a/cmd/tagger.go
+++ b/cmd/tagger.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/konveyor/tackle2-addon/command"
+	"github.com/konveyor/tackle2-hub/api"
+	"io"
+	"math/rand"
+	"os"
+	pathlib "path"
+)
+
+//
+// Tagger tags an application.
+type Tagger struct {
+	Enabled bool `json:"enabled"`
+}
+
+//
+// AddOptions adds windup options.
+func (r *Tagger) AddOptions(options *command.Options) (err error) {
+	if r.Enabled {
+		options.Add("--exportSummary")
+	}
+	return
+}
+
+//
+// Update updates application tags.
+//   - Ensures categories exist.
+//   - Endures tags exist.
+//   - Replaces associated tags (by source).
+func (r *Tagger) Update(appID uint) (err error) {
+	addon.Activity("[TAG] Tagging Application %d.", appID)
+	report, err := r.report()
+	if err != nil {
+		return
+	}
+	catMap, err := r.ensureCategories(report)
+	if err != nil {
+		return
+	}
+	wanted, err := r.ensureTags(catMap, report)
+	if err != nil {
+		return
+	}
+	err = r.ensureAssociated(appID, wanted)
+	if err != nil {
+		return
+	}
+	return
+}
+
+//
+// report reads and returns the json summary.
+// Returns the summary.
+func (r *Tagger) report() (report []Summary, err error) {
+	path := pathlib.Join(ReportDir, "analysisSummary.json")
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return
+	}
+	report = []Summary{}
+	err = json.Unmarshal(b, &report)
+	if err != nil {
+		return
+	}
+	return
+}
+
+//
+// ensureCategories ensures categories exist.
+// Returns the map of category names to IDs.
+func (r *Tagger) ensureCategories(report []Summary) (mp map[string]uint, err error) {
+	mp = map[string]uint{}
+	wanted := []api.TagCategory{}
+	for i := range report {
+		for _, tag := range report[i].Tags {
+			mp[tag.Category] = 0
+		}
+		for name := range mp {
+			wanted = append(
+				wanted,
+				api.TagCategory{
+					Name:  name,
+					Color: r.nextColor(),
+					Rank:  uint(rand.Intn(10)),
+				})
+		}
+	}
+	for _, cat := range wanted {
+		err = addon.TagCategory.Ensure(&cat)
+		if err != nil {
+			return
+		}
+		mp[cat.Name] = cat.ID
+	}
+	return
+}
+
+//
+// ensureTags ensures tags exist.
+// Returns the wanted tag IDs.
+func (r *Tagger) ensureTags(catMap map[string]uint, report []Summary) (tags []uint, err error) {
+	mp := map[TagRef]int{}
+	wanted := []api.Tag{}
+	for i := range report {
+		for _, ref := range report[i].Tags {
+			mp[ref] = 0
+		}
+		for ref := range mp {
+			catRef := api.Ref{
+				ID: catMap[ref.Category],
+			}
+			wanted = append(
+				wanted,
+				api.Tag{
+					Name:     ref.Name,
+					Category: catRef,
+				})
+		}
+	}
+	for _, tag := range wanted {
+		err = addon.Tag.Ensure(&tag)
+		if err != nil {
+			return
+		}
+		tags = append(tags, tag.ID)
+	}
+	return
+}
+
+//
+// ensureAssociated ensure wanted tags are associated.
+func (r *Tagger) ensureAssociated(appID uint, wanted []uint) (err error) {
+	tags := addon.Application.Tags(appID)
+	tags.Source("Analysis")
+	err = tags.Replace(wanted)
+	return
+}
+
+//
+// nextColor generates random colors.
+func (r *Tagger) nextColor() (color string) {
+	R := rand.Intn(255)
+	G := rand.Intn(255)
+	B := rand.Intn(255)
+	color = fmt.Sprintf("#%.2x%.2x%.2x", R, G, B)
+	return
+}
+
+//
+// Summary windup object.
+type Summary struct {
+	Tags []TagRef `json:"technologyTags"`
+}
+
+//
+// TagRef is a tag name & category.
+type TagRef struct {
+	Name     string `json:"name"`
+	Category string `json:"category"`
+}

--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -66,6 +66,10 @@ func (r *Windup) options() (options command.Options, err error) {
 	if err != nil {
 		return
 	}
+	err = r.Tagger.AddOptions(&options)
+	if err != nil {
+		return
+	}
 	err = r.Mode.AddOptions(&options)
 	if err != nil {
 		return


### PR DESCRIPTION
Tag the application using the _Analysis_ source using the windup JSON summary report.

Adds: Data.**Tagger.Enabled** (bool) enable tagging.
