### PR TITLE
:sparkles: Support remote repositories not associated with applications.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,9 +105,12 @@ func main() {
 		//
 		// Maven.
 		maven := repository.Maven{
-			Application: application,
-			M2Dir:       M2Dir,
-			BinDir:      DepDir,
+			M2Dir:  M2Dir,
+			BinDir: DepDir,
+			Remote: repository.Remote{
+				Repository: application.Repository,
+				Identities: application.Identities,
+			},
 		}
 		//
 		// SSH
@@ -134,8 +137,11 @@ func main() {
 						application.Repository.URL),
 					".")[0])
 			AppDir = path.Join(SourceDir, application.Repository.Path)
-			var r repository.Repository
-			r, err = repository.New(SourceDir, application)
+			var r repository.SCM
+			r, err = repository.New(
+				SourceDir,
+				application.Repository,
+				application.Identities)
 			if err != nil {
 				return
 			}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -170,7 +170,7 @@ func main() {
 			}
 		} else {
 			if d.Mode.Artifact == "" {
-				err = maven.FetchArtifact()
+				err = maven.FetchArtifact(application.Binary)
 				if err != nil {
 					return
 				}

--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -151,7 +151,7 @@ type Mode struct {
 	WithDeps   bool   `json:"withDeps"`
 	Diva       bool   `json:"diva"`
 	CSV        bool   `json:"csv"`
-	Repository repository.Repository
+	Repository repository.SCM
 }
 
 //
@@ -403,12 +403,10 @@ func (r *Rules) addBundleRepository(options *command.Options, bundle *api.RuleBu
 	if err != nil {
 		return
 	}
-	owner := &api.Application{}
-	owner.Repository = bundle.Repository
-	if bundle.Identity != nil {
-		owner.Identities = []api.Ref{*bundle.Identity}
-	}
-	rp, err := repository.New(rootDir, owner)
+	rp, err := repository.New(
+		rootDir,
+		bundle.Repository,
+		[]api.Ref{*bundle.Identity})
 	if err != nil {
 		return
 	}
@@ -440,12 +438,10 @@ func (r *Rules) addRepository(options *command.Options) (err error) {
 	if err != nil {
 		return
 	}
-	owner := &api.Application{}
-	owner.Repository = r.Repository
-	if r.Identity != nil {
-		owner.Identities = []api.Ref{*r.Identity}
-	}
-	rp, err := repository.New(rootDir, owner)
+	rp, err := repository.New(
+		rootDir,
+		r.Repository,
+		[]api.Ref{*r.Identity})
 	if err != nil {
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-
 
 require (
 	github.com/konveyor/tackle2-addon v0.0.0-20230118205230-1aba7c8edc09
-	github.com/konveyor/tackle2-hub v0.0.0-20230310172525-a91d730eb74d
+	github.com/konveyor/tackle2-hub v0.0.0-20230328174512-4dc247934b8a
 )
 
-replace github.com/konveyor/tackle2-addon => github.com/jortel/tackle2-addon v0.0.0-20230328180238-2bc136bc486b
+replace github.com/konveyor/tackle2-addon => github.com/jortel/tackle2-addon v0.0.0-20230329171414-e451e3d94622

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/konveyor/tackle2-addon v0.0.0-20230118205230-1aba7c8edc09
 	github.com/konveyor/tackle2-hub v0.0.0-20230310172525-a91d730eb74d
 )
+
+replace github.com/konveyor/tackle2-addon => github.com/jortel/tackle2-addon v0.0.0-20230328180238-2bc136bc486b

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,6 @@ replace k8s.io/api => k8s.io/api v0.0.0-20181213150558-05914d821849
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20181213153335-0fe22c71c476
 
 require (
-	github.com/konveyor/tackle2-addon v0.0.0-20230118205230-1aba7c8edc09
-	github.com/konveyor/tackle2-hub v0.0.0-20230328174512-4dc247934b8a
+	github.com/konveyor/tackle2-addon v0.0.0-20230329181503-cc8ac05b87a1
+	github.com/konveyor/tackle2-hub v0.0.0-20230328195711-114d242834e3
 )
-
-replace github.com/konveyor/tackle2-addon => github.com/jortel/tackle2-addon v0.0.0-20230329171414-e451e3d94622

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jortel/tackle2-addon v0.0.0-20230328180238-2bc136bc486b h1:XIctgb4+g/pvTFlpjQ2yzwmqXXOuB72oxePbwez3fNg=
+github.com/jortel/tackle2-addon v0.0.0-20230328180238-2bc136bc486b/go.mod h1:enKHvtUe1HK4Khgo4H96U8/CaQvvBZiH9cD7I62A0zA=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -341,8 +343,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
-github.com/konveyor/tackle2-addon v0.0.0-20230118205230-1aba7c8edc09 h1:7dVrx+2Nkkm/qFsD/YGW+Fl8cwPO41BhgSKj4UxTH4s=
-github.com/konveyor/tackle2-addon v0.0.0-20230118205230-1aba7c8edc09/go.mod h1:enKHvtUe1HK4Khgo4H96U8/CaQvvBZiH9cD7I62A0zA=
 github.com/konveyor/tackle2-hub v0.0.0-20230118203912-beb582e472d9/go.mod h1:/YlrzuavATpAvimbDMDW3w4tO45IAIsg9jSK48lTSr4=
 github.com/konveyor/tackle2-hub v0.0.0-20230310172525-a91d730eb74d h1:K/kpVwOWuiltvGvZCTGSxU26u+J9FCnWD++3IM/lRe8=
 github.com/konveyor/tackle2-hub v0.0.0-20230310172525-a91d730eb74d/go.mod h1:/Eyz1COkX9TpS/52Mrmfc1BECFpH9+sS5u69jH6krQI=

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,6 @@ github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jortel/tackle2-addon v0.0.0-20230329171414-e451e3d94622 h1:bY8O+apWXsXwwHARgtxxyQJKnMctG6aHhKTG8JB2yNg=
-github.com/jortel/tackle2-addon v0.0.0-20230329171414-e451e3d94622/go.mod h1:jJ0TkG0uGj+2JlmCQiuZPPKEbIv2cOypsnQ2oiDDeDk=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -343,8 +341,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
-github.com/konveyor/tackle2-hub v0.0.0-20230328174512-4dc247934b8a h1:TuEM4NEji805j2kyhnX7xWVvregN6LUMC0bmyCIF0yo=
+github.com/konveyor/tackle2-addon v0.0.0-20230329181503-cc8ac05b87a1 h1:00kis6k6eRVhFGIZnHUKpA1cgw+jf7Xme3hZg7E2A1o=
+github.com/konveyor/tackle2-addon v0.0.0-20230329181503-cc8ac05b87a1/go.mod h1:jJ0TkG0uGj+2JlmCQiuZPPKEbIv2cOypsnQ2oiDDeDk=
 github.com/konveyor/tackle2-hub v0.0.0-20230328174512-4dc247934b8a/go.mod h1:/Eyz1COkX9TpS/52Mrmfc1BECFpH9+sS5u69jH6krQI=
+github.com/konveyor/tackle2-hub v0.0.0-20230328195711-114d242834e3 h1:ZsAxlC+oXRrLYzCgHhcImjfLv6h0IFeyW5zzymZaPS4=
+github.com/konveyor/tackle2-hub v0.0.0-20230328195711-114d242834e3/go.mod h1:/Eyz1COkX9TpS/52Mrmfc1BECFpH9+sS5u69jH6krQI=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,8 @@ github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/jortel/tackle2-addon v0.0.0-20230328180238-2bc136bc486b h1:XIctgb4+g/pvTFlpjQ2yzwmqXXOuB72oxePbwez3fNg=
-github.com/jortel/tackle2-addon v0.0.0-20230328180238-2bc136bc486b/go.mod h1:enKHvtUe1HK4Khgo4H96U8/CaQvvBZiH9cD7I62A0zA=
+github.com/jortel/tackle2-addon v0.0.0-20230329171414-e451e3d94622 h1:bY8O+apWXsXwwHARgtxxyQJKnMctG6aHhKTG8JB2yNg=
+github.com/jortel/tackle2-addon v0.0.0-20230329171414-e451e3d94622/go.mod h1:jJ0TkG0uGj+2JlmCQiuZPPKEbIv2cOypsnQ2oiDDeDk=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -343,9 +343,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/controller v0.8.0 h1:TB4KOqnWKzpuW0LLI571NzQYIXI/bmcf9K1vl8ctVkg=
 github.com/konveyor/controller v0.8.0/go.mod h1:U2h8HnX1MXoUlLA8ySP+PJClK9+aR38mxtqLGAvAprE=
-github.com/konveyor/tackle2-hub v0.0.0-20230118203912-beb582e472d9/go.mod h1:/YlrzuavATpAvimbDMDW3w4tO45IAIsg9jSK48lTSr4=
-github.com/konveyor/tackle2-hub v0.0.0-20230310172525-a91d730eb74d h1:K/kpVwOWuiltvGvZCTGSxU26u+J9FCnWD++3IM/lRe8=
-github.com/konveyor/tackle2-hub v0.0.0-20230310172525-a91d730eb74d/go.mod h1:/Eyz1COkX9TpS/52Mrmfc1BECFpH9+sS5u69jH6krQI=
+github.com/konveyor/tackle2-hub v0.0.0-20230328174512-4dc247934b8a h1:TuEM4NEji805j2kyhnX7xWVvregN6LUMC0bmyCIF0yo=
+github.com/konveyor/tackle2-hub v0.0.0-20230328174512-4dc247934b8a/go.mod h1:/Eyz1COkX9TpS/52Mrmfc1BECFpH9+sS5u69jH6krQI=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -383,8 +382,6 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-sqlite3 v1.14.4/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
-github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
-github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -911,7 +908,6 @@ gorm.io/driver/mysql v1.3.5 h1:iWBTVW/8Ij5AG4e0G/zqzaJblYkBI1VIL1LG2HUGsvY=
 gorm.io/driver/mysql v1.3.5/go.mod h1:sSIebwZAVPiT+27jK9HIwvsqOGKx3YMPmrA3mBJR10c=
 gorm.io/driver/postgres v1.2.3 h1:f4t0TmNMy9gh3TU2PX+EppoA6YsgFnyq8Ojtddb42To=
 gorm.io/driver/postgres v1.2.3/go.mod h1:pJV6RgYQPG47aM1f0QeOzFH9HxQc8JcmAgjRCgS0wjs=
-gorm.io/driver/sqlite v1.3.6/go.mod h1:Sg1/pvnKtbQ7jLXxfZa+jSHvoX8hoZA8cn4xllOMTgE=
 gorm.io/driver/sqlite v1.4.4 h1:gIufGoR0dQzjkyqDyYSCvsYR6fba1Gw5YKDqKeChxFc=
 gorm.io/driver/sqlite v1.4.4/go.mod h1:0Aq3iPO+v9ZKbcdiz8gLWRw5VOPcBOPUQJFLq5e2ecI=
 gorm.io/driver/sqlserver v1.2.1 h1:KhGOjvPX7JZ5hPyQICTJfMuTz88zgJ2lk9bWiHVNHd8=
@@ -919,7 +915,6 @@ gorm.io/driver/sqlserver v1.2.1/go.mod h1:nixq0OB3iLXZDiPv6JSOjWuPgpyaRpOIIevYtA
 gorm.io/gorm v1.22.2/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.22.3/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.22.4/go.mod h1:1aeVC+pe9ZmvKZban/gW4QPra7PRoTEssyc922qCAkk=
-gorm.io/gorm v1.23.4/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.24.0/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
 gorm.io/gorm v1.24.5 h1:g6OPREKqqlWq4kh/3MCQbZKImeB9e6Xgc4zD+JgNZGE=


### PR DESCRIPTION
Support remote repositories not associated with applications.
Updated to work with tackle2-addon _repository_ support packages.

**Requires**: go.mod update after https://github.com/konveyor/tackle2-addon/pull/32 is merged.