### PR TITLE
:bug: Using windup 6.1.7 and --exitCodes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ git \
 subversion \
 maven \
 && microdnf -y clean all
-ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.4.Final/tackle-cli-6.1.4.Final-offline.zip
+ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.7.Final/tackle-cli-6.1.7.Final-offline.zip
 RUN wget -qO /opt/windup.zip $WINDUP \
  && unzip /opt/windup.zip -d /opt \
  && rm /opt/windup.zip \

--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -89,6 +89,7 @@ func (r *Windup) reportLog() {
 // options builds CLL options.
 func (r *Windup) options() (options command.Options, err error) {
 	options = command.Options{
+		"--exitCodes",
 		"--batchMode",
 		"--output",
 		ReportDir,


### PR DESCRIPTION
Using windup 6.1.7 and --exitCodes. Fixes windup exit (non-zero) on failure. This GREATLY improves effort detection, reporting and troubleshooting.

https://issues.redhat.com/browse/MTA-389