### PR TITLE
Trim extra newlines from Empty ruleset xml

### DIFF
--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -19,8 +19,7 @@ import (
 // EmptyRuleSet provides an empty ruleset.
 // Windup requires at least 1 target passed.
 var (
-	EmptyRuleSet = `
-<?xml version="1.0"?>
+	EmptyRuleSet = `<?xml version="1.0"?>
 <ruleset id="Empty"
     xmlns="http://windup.jboss.org/schema/jboss-ruleset"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -29,8 +28,7 @@ var (
         <targetTechnology id="Empty"/>
     </metadata>
     <rules/>
-</ruleset>
-`
+</ruleset>`
 )
 
 //


### PR DESCRIPTION
Quoting from this [Stack Overflow answer](https://stackoverflow.com/questions/19889132/error-the-processing-instruction-target-matching-xxmmll-is-not-allowed):

> Xerces-based tools will emit the following error
> `The processing instruction target matching "[xX][mM][lL]" is not allowed.`
> when an [XML declaration](http://www.w3.org/TR/REC-xml/#NT-XMLDecl) is encountered anywhere other than at the top of an XML file.

This includes leading newlines, whitespace, and even some invisible characters such as BOMs. This PR removes the leading (and trailing, for good measure) newline from the Empty ruleset xml to avoid validation problems.