### PR TITLE
:sparkles: windup 6.3.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ git \
 subversion \
 maven \
 && microdnf -y clean all
-ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.1.7.Final/tackle-cli-6.1.7.Final-offline.zip
+ARG WINDUP=https://repo1.maven.org/maven2/org/jboss/windup/tackle-cli/6.3.2.Final/tackle-cli-6.3.2.Final-offline.zip
 RUN wget -qO /opt/windup.zip $WINDUP \
  && unzip /opt/windup.zip -d /opt \
  && rm /opt/windup.zip \

--- a/cmd/windup.go
+++ b/cmd/windup.go
@@ -87,6 +87,7 @@ func (r *Windup) reportLog() {
 // options builds CLL options.
 func (r *Windup) options() (options command.Options, err error) {
 	options = command.Options{
+		"--legacyReports",
 		"--exitCodes",
 		"--batchMode",
 		"--output",


### PR DESCRIPTION
Fixes CVEs.

THIS ONLY MERGED TO release-0.1.  Not pack-ported from main.